### PR TITLE
Show empty list when search text is empty

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,15 +6,9 @@ import { ActionPanel, Action, List, Icon } from "@raycast/api";
 export default function Command() {
   const [searchText, setSearchText] = useState("");
 
-  if (searchText.length === 0) {
-    // Don't fire search if query is empty
-    // https://github.com/rhubarbgroup/raycast-wordpress-docs/issues/1
-  }
-
-  const query = searchText.length === 0 ? "get_" : searchText;
-
-  const { data, isLoading } = useFetch(`https://developer.wordpress.org/search/${query}/feed/rss/`, {
+  const { data, isLoading } = useFetch(`https://developer.wordpress.org/search/${searchText}/feed/rss/`, {
     parseResponse: parseFetchResponse,
+    execute: searchText.length > 0,
   });
 
   return (
@@ -24,11 +18,15 @@ export default function Command() {
       searchBarPlaceholder="Search WordPress code reference..."
       throttle
     >
-      <List.Section title="Results" subtitle={data?.length + ""}>
-        {data?.map((searchResult: SearchResult) => (
-          <SearchListItem key={searchResult.name} searchResult={searchResult} />
-        ))}
-      </List.Section>
+      {searchText.length > 0 ? (
+        <List.Section title="Results" subtitle={data?.length + ""}>
+          {data?.map((searchResult: SearchResult) => (
+            <SearchListItem key={searchResult.name} searchResult={searchResult} />
+          ))}
+        </List.Section>
+      ) : (
+        <List.EmptyView title={"Type to search"} icon={{ source: "command-icon.png" }} />
+      )}
     </List>
   );
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,7 +25,7 @@ export default function Command() {
           ))}
         </List.Section>
       ) : (
-        <List.EmptyView title={"Type to search"} icon={{ source: "command-icon.png" }} />
+        <List.EmptyView title={"Type to search"} />
       )}
     </List>
   );


### PR DESCRIPTION
To not execute fetch when search test is empty I used `execute` option of `useFetch` hook.
Also I used `List.EmptyView` when search text is empty.